### PR TITLE
Added working support for blob storage in cassandra. Previously blobs…

### DIFF
--- a/export.js
+++ b/export.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var jsonStream = require('JSONStream');
 
 var HOST = process.env.HOST || '127.0.0.1';
+var PORT = process.env.PORT || 9042;
 var KEYSPACE = process.env.KEYSPACE;
 
 if (!KEYSPACE) {
@@ -20,8 +21,8 @@ if (USER && PASSWORD) {
     authProvider = new cassandra.auth.PlainTextAuthProvider(USER, PASSWORD);
 }
 
-var systemClient = new cassandra.Client({contactPoints: [HOST], authProvider: authProvider});
-var client = new cassandra.Client({ contactPoints: [HOST], keyspace: KEYSPACE, authProvider: authProvider});
+var systemClient = new cassandra.Client({contactPoints: [HOST], authProvider: authProvider, protocolOptions: {port: [PORT]}});
+var client = new cassandra.Client({ contactPoints: [HOST], keyspace: KEYSPACE, authProvider: authProvider, protocolOptions: {port: [PORT]}});
 
 function processTableExport(table) {
     console.log('==================================================');


### PR DESCRIPTION
… were

being correctly serialized as a json object with the format:
{"type": "Buffer", "data": [<buffer data>]}
But on de-serialization the json object was being passed directly to the
cassandra driver instead of a Buffer object being constructed from the
json object.

I had get rid of the batch processing to achieve this as even small
(1-2MB) blobs can cause a single query to exceed the batch size limit.
Since batches should only be used for multi-table queries that require
synchronization (a situation which is impossible in this context) or for
single partition multi-query batches (a situation which is very unlikely
in this context), this isn't a problem. cf.
https://docs.datastax.com/en/cql/3.3/cql/cql_using/useBatchGoodExample.html

Modified import.js and export.js to support PORT environment variable as
it was convenient during debugging.